### PR TITLE
Feature 122 inject apikey header

### DIFF
--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -8,3 +8,4 @@ GITHUB_CLIENT_SECRET=your_github_client_secret
 GITHUB_CALLBACK_URL=http://localhost:3000/auth/github/callback
 
 DATABASE_WEBAPP="<YOUR DATABASE URI>"
+DEFAULT_API_KEY=<YOUR DEFAULT API KEY>

--- a/apps/client/app/routes/_layout.templates.tsx
+++ b/apps/client/app/routes/_layout.templates.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import { Template } from '~/models/template.model';
 import { PlusIcon } from '@heroicons/react/16/solid';
 import { getTemplates } from '~/services/templates/templates.service';
+import { authenticator } from "~/services";
 
 export const meta: MetaFunction = () => {
   return [{ title: 'Templates · Ethereal Pulse' }];
@@ -12,7 +13,8 @@ export const meta: MetaFunction = () => {
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
   const searchedStr = url.searchParams.get('templates');
-  const templates = await getTemplates(searchedStr);
+  const userId: string | null = await authenticator.isAuthenticated(request);
+  const templates = await getTemplates(userId, searchedStr);
   return json({ templates, searchedStr });
 };
 

--- a/apps/client/app/services/templates/templates.service.ts
+++ b/apps/client/app/services/templates/templates.service.ts
@@ -1,5 +1,6 @@
 import { MOCKED_TEMPLATES } from "~/mocks/templates";
 import { Template } from "~/models/template.model";
+import { getWithApiKey } from "~/utils/requests";
 
 /*
 * Simulates server requests to fetch for a particular templates,
@@ -8,13 +9,15 @@ import { Template } from "~/models/template.model";
 const DELAY = 500;
 
 export async function getTemplates(searchString: string | null): Promise<Template[]> {
-  const result = searchString?.length ?
-    MOCKED_TEMPLATES.filter((item) => item.name.toLowerCase().includes(searchString.toLowerCase())) :
-    MOCKED_TEMPLATES
+  // const result = searchString?.length ?
+  //   MOCKED_TEMPLATES.filter((item) => item.name.toLowerCase().includes(searchString.toLowerCase())) :
+  //   MOCKED_TEMPLATES
 
-  return new Promise<Template[]>((resolve) => {
-    setTimeout(() => {resolve(result);}, DELAY)
-  })
+  // TODO IMPLEMENT SEARCH STRING USAGE IN API CALL
+  console.log(searchString);
+
+  const templates: Template[] = await getWithApiKey<Template[]>('https://ethereal-pulse-server.proudglacier-d2cd577c.westeurope.azurecontainerapps.io/templates');
+  return templates;
 }
 
 export async function getTemplateById(id: string) {

--- a/apps/client/app/services/templates/templates.service.ts
+++ b/apps/client/app/services/templates/templates.service.ts
@@ -8,15 +8,14 @@ import { getWithApiKey } from "~/utils/requests";
 * */
 const DELAY = 500;
 
-export async function getTemplates(searchString: string | null): Promise<Template[]> {
+export async function getTemplates(userId: string | null, searchString: string | null): Promise<Template[]> {
   // const result = searchString?.length ?
   //   MOCKED_TEMPLATES.filter((item) => item.name.toLowerCase().includes(searchString.toLowerCase())) :
   //   MOCKED_TEMPLATES
 
   // TODO IMPLEMENT SEARCH STRING USAGE IN API CALL
   console.log(searchString);
-
-  const templates: Template[] = await getWithApiKey<Template[]>('https://ethereal-pulse-server.proudglacier-d2cd577c.westeurope.azurecontainerapps.io/templates');
+  const templates: Template[] = await getWithApiKey<Template[]>('https://ethereal-pulse-server.proudglacier-d2cd577c.westeurope.azurecontainerapps.io/templates', userId ? { 'x-user-id': userId } : undefined);
   return templates;
 }
 

--- a/apps/client/app/utils/index.ts
+++ b/apps/client/app/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './helpers';
 export * from './hooks';
+export * from './requests';

--- a/apps/client/app/utils/requests.test.ts
+++ b/apps/client/app/utils/requests.test.ts
@@ -1,0 +1,77 @@
+
+import { getWithApiKey, postWithApiKey } from "./requests";
+import { describe, it, expect, vi, beforeAll, afterEach, beforeEach } from 'vitest';
+
+
+describe('requests.ts', () => {
+  const mockFetch = vi.fn();
+  const defaultApiKey = 'mock-default-api-key';
+  beforeAll(() => {
+    global.fetch = mockFetch;
+    process.env['DEFAULT_API_KEY'] = defaultApiKey;
+  });
+
+  beforeEach(() => {
+    process.env['DEFAULT_API_KEY'] = defaultApiKey;
+  });
+
+  afterEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('should make a GET request with the API key', async () => {
+    const mockResponse = { data: 'test' };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await getWithApiKey('https://api.example.com/data');
+
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/data', {
+      method: 'GET',
+      headers: {
+        'x-api-key': defaultApiKey,
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should make a POST request with the API key and body', async () => {
+    const mockResponse = { data: 'test' };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const body = { key: 'value' };
+    const result = await postWithApiKey('https://api.example.com/data', body);
+
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/data', {
+      method: 'POST',
+      headers: {
+        'x-api-key': defaultApiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should throw an error if the API key is missing', async () => {
+    delete process.env.DEFAULT_API_KEY;
+
+    await expect(getWithApiKey('https://api.example.com/data')).rejects.toThrow('API key is missing');
+  });
+
+  it('should throw an error if the response is not ok', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    await expect(getWithApiKey('https://api.example.com/data')).rejects.toThrow('HTTP error! status: 404');
+  });
+});
+

--- a/apps/client/app/utils/requests.ts
+++ b/apps/client/app/utils/requests.ts
@@ -1,0 +1,58 @@
+interface RequestOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+export async function getWithApiKey<T>(url: string, headers: Record<string, string> = {}): Promise<T> {
+  return requestWithApiKey<T>(url, {
+    method: 'GET',
+    headers,
+  });
+}
+
+export async function postWithApiKey<T>(url: string, body: unknown, headers: Record<string, string> = {}): Promise<T> {
+  return requestWithApiKey<T>(url, {
+    method: 'POST',
+    headers,
+    body,
+  });
+}
+
+async function requestWithApiKey<T>(url: string, options: RequestOptions = {}): Promise<T> {
+  const { method = 'GET', headers = {}, body } = options;
+
+  const defaultApiKey = process.env.DEFAULT_API_KEY;
+
+  if (!defaultApiKey) {
+    throw new Error('API key is missing');
+  }
+
+  // Add the API key to the headers
+  const finalHeaders: Record<string, string> = {
+    ...headers,
+    'x-api-key': defaultApiKey,
+    'Content-Type': 'application/json',
+  };
+
+  // Configure the fetch options
+  const fetchOptions: RequestInit = {
+    method,
+    headers: finalHeaders,
+  };
+
+  if (body) {
+    fetchOptions.body = JSON.stringify(body);
+  }
+
+  // Make the fetch request
+  const response = await fetch(url, fetchOptions);
+
+  // Check if the response is ok (status in the range 200-299)
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  // Parse and return the JSON response
+  return response.json() as Promise<T>;
+}

--- a/apps/server/src/templates/controller/template.controller.ts
+++ b/apps/server/src/templates/controller/template.controller.ts
@@ -22,6 +22,7 @@ export class TemplateController {
 
   @Get()
   async findAll(): Promise<Template[]> {
+    console.log('TESTE!!!!!');
     return this._templateService.findAll();
   }
 

--- a/apps/server/src/templates/controller/template.controller.ts
+++ b/apps/server/src/templates/controller/template.controller.ts
@@ -22,7 +22,6 @@ export class TemplateController {
 
   @Get()
   async findAll(): Promise<Template[]> {
-    console.log('TESTE!!!!!');
     return this._templateService.findAll();
   }
 


### PR DESCRIPTION
### Resolves 122

### Description
Add a mechanism to include the API key as a header in requests made to the server. This mechanism should be executed on the server side to prevent clients from accessing the API key.

### Definition of Done
- [ ] Acceptance Criteria is fulfilled
- [ ] Changes and issues encountered are documented
- [ ] Github issue is linked in this PR
